### PR TITLE
Makefile enhancements to optimize local workflows (#363)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Here's all notable changes and commits to both the configuration repo and the ba
 Many thanks to all those who have submitted issues and pull requests to make this firmware better!
 ## Config repo
 
+2/2/2024 - Makefile enhancements (build left side firmware only, separate clean targets for firmware and docker, reset of version.dtsi after build) [#363](https://github.com/KinesisCorporation/Adv360-Pro-ZMK/pull/363)
+
 1/16/2024 - Change the makefile to fis WSL2 compatibility [#335](https://github.com/KinesisCorporation/Adv360-Pro-ZMK/pull/335)
 
 1/14/2024 - Update base ZMK, change KConfig attributes to support, Enable experimental BLE features for improved stability [#326](https://github.com/KinesisCorporation/Adv360-Pro-ZMK/pull/326)

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ SELINUX1 := :z
 SELINUX2 := ,z
 endif
 
-.PHONY: all clean
+.PHONY: all left clean_firmware clean_image clean
 
 all:
 	$(shell bin/get_version.sh >> /dev/null)
@@ -20,8 +20,26 @@ all:
 		-v $(PWD)/config:/app/config:ro$(SELINUX2) \
 		-e TIMESTAMP=$(TIMESTAMP) \
 		-e COMMIT=$(COMMIT) \
+		-e BUILD_RIGHT=true \
 		zmk
+	$(shell git checkout config/version.dtsi)
 
-clean:
+left:
+	$(shell bin/get_version.sh >> /dev/null)
+	$(DOCKER) build --tag zmk --file Dockerfile .
+	$(DOCKER) run --rm -it --name zmk \
+		-v $(PWD)/firmware:/app/firmware$(SELINUX1) \
+		-v $(PWD)/config:/app/config:ro$(SELINUX2) \
+		-e TIMESTAMP=$(TIMESTAMP) \
+		-e COMMIT=$(COMMIT) \
+		-e BUILD_RIGHT=false \
+		zmk
+	$(shell git checkout config/version.dtsi)
+
+clean_firmware:
 	rm -f firmware/*.uf2
+
+clean_image:
 	$(DOCKER) image rm zmk docker.io/zmkfirmware/zmk-build-arm:stable
+
+clean: clean_firmware clean_image

--- a/README.md
+++ b/README.md
@@ -35,14 +35,33 @@ Certain ZMK features (e.g. combos) require knowing the exact key positions in th
 * Install make using `sudo apt-get install make` inside the WSL2 instance.
 * The repository can be cloned directly into the WSL2 instance or accessed through the C: mount point WSL provides by default (`/mnt/c/path-to-repo`).
 
-### Build firmware
+#### macOS specific
 
-1. Execute `make`.
-2. Check the `firmware` directory for the latest firmware build.
+On macOS [brew](https://brew.sh) can be used to install the required components.
+
+* docker
+* [colima](https://github.com/abiosoft/colima) can be used as the docker engine
+
+```shell
+brew install docker colima
+colima start
+```
+> Note: On Apple Silicon (ARM based) systems you need to make sure to start colima with the correct architecture for the container being used.
+> ```
+> colima start --arch x86_64
+> ```
+
+
+### Build firmware locally
+
+1. Execute `make` to build firmware for both halves or `make left` to only build firmware for the left hand side.
+2. Check the `firmware` directory for the latest firmware build. The first part of the filename is the timestamp when the firmware was built.
 
 ### Cleanup
 
-The built docker container and compiled firmware files can be deleted with `make clean`. This might be necessary if you updated your fork from V2.0 to V3.0 and are encountering build failures. 
+The built docker container and compiled firmware files can be deleted with `make clean`. This might be necessary if you updated your fork from V2.0 to V3.0 and are encountering build failures.
+
+Creating the docker container takes some time. Therefore `make clean_firmware` can be used to only clean firmware without removing the docker container. Similarly `make clean_image` can be used to remove the docker container without removing compiled firmware files.
 
 ## Flashing firmware
 

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -10,9 +10,15 @@ COMMIT="${COMMIT:-$(echo xxxxxx)}"
 west build -s zmk/app -d build/left -b adv360_left -- -DZMK_CONFIG="${PWD}/config"
 # Adv360 Left Kconfig file
 grep -vE '(^#|^$)' build/left/zephyr/.config
-# West Build (right)
-west build -s zmk/app -d build/right -b adv360_right -- -DZMK_CONFIG="${PWD}/config"
-# Adv360 Right Kconfig file
-grep -vE '(^#|^$)' build/right/zephyr/.config
 # Rename zmk.uf2
-cp build/left/zephyr/zmk.uf2 "./firmware/${TIMESTAMP}-${COMMIT}-left.uf2" && cp build/right/zephyr/zmk.uf2 "./firmware/${TIMESTAMP}-${COMMIT}-right.uf2"
+cp build/left/zephyr/zmk.uf2 "./firmware/${TIMESTAMP}-${COMMIT}-left.uf2"
+
+# Build right side if selected
+if [ "${BUILD_RIGHT}" = true ]; then
+    # West Build (right)
+    west build -s zmk/app -d build/right -b adv360_right -- -DZMK_CONFIG="${PWD}/config"
+    # Adv360 Right Kconfig file
+    grep -vE '(^#|^$)' build/right/zephyr/.config
+    # Rename zmk.uf2
+    cp build/right/zephyr/zmk.uf2 "./firmware/${TIMESTAMP}-${COMMIT}-right.uf2"
+fi


### PR DESCRIPTION
- Enhance the Makefile to enable firmware building exclusively for the left side.

To modify the keymap, flashing only the left side's firmware suffices.

This change facilitates the creation of firmware for the left side only, thereby expediting the build process.

Usage: make left

This update maintains existing functionality. Without specifying the left target, firmware for both halves will be generated.

- Add separate make targets to clean firmware and docker image

Add targets clean_firmware and clean_image independently while maintaing clean to run both

- Ensure files modified by the build process are reset at the end

The current build process dynamically generates the content of the version macro in config/version.dtsi to enable users to print out the precise version and commit the firmware was built on via a keybinding on the keymap.

This change ensurs that the changes to this macro file are reset at the end of the build process to ensure it isn't shown as modified and added to keymap commit changes.

## Advantage 360 Pro PR template

### What's changed:

### Why has this change been implemented:

### What (if any) actions must a user take after this change:

